### PR TITLE
repair incompatibility with deep reference and borken changed above p…

### DIFF
--- a/cvtorchvision/__init__.py
+++ b/cvtorchvision/__init__.py
@@ -1,1 +1,1 @@
-from cvtorchvision import cvtransforms
+from . import cvtransforms

--- a/cvtorchvision/cvtransforms/cvfunctional.py
+++ b/cvtorchvision/cvtransforms/cvfunctional.py
@@ -9,7 +9,7 @@ cv2.ocl.setUseOpenCL(False)
 import numpy as np
 import numbers
 import types
-import collections
+import collections.abc as collections
 import warnings
 import matplotlib.pyplot as plt
 from torchvision.transforms import functional
@@ -285,7 +285,7 @@ def crop(img, x, y, h, w):
 def center_crop(img, output_size):
     if isinstance(output_size, numbers.Number):
         output_size = (int(output_size), int(output_size))
-    h, w, _ = img.shape
+    h, w = img.shape[:2]
     th, tw = output_size
     i = int(round((h - th) * 0.5))
     j = int(round((w - tw) * 0.5))

--- a/cvtorchvision/cvtransforms/cvtransforms.py
+++ b/cvtorchvision/cvtransforms/cvtransforms.py
@@ -8,9 +8,9 @@ cv2.ocl.setUseOpenCL(False)
 import numpy as np
 import numbers
 import types
-import collections
+import collections.abc as collections
 
-from cvtorchvision.cvtransforms import cvfunctional as F
+from . import cvfunctional as F
 
 
 __all__ = ["Compose", "ToTensor", "ToCVImage",


### PR DESCRIPTION
1. When "cvtorchvision" folder is not in the default search path, e.g., not in the top-level folder of the project, directly import like "from cvtorchvision import cvtransforms" will throw an error. This PR will repair it by using relative import like "from . import cvtransforms".
2. According to the offical Python documentation (https://docs.python.org/3.9/library/collections.html) , Collections Abstract Base Classes in "collections" module has been moved to "collections.abc" module since version 3.3, and it is deleted completely in "collections" module at version 3.10 and later. So the current code will throw an error while running the latest Python. This PR propose a workaround by "import collections.abc as collections" instead, which is not beautiful but works.